### PR TITLE
fix setting of '*' in repl

### DIFF
--- a/src/main/java/com/en_circle/slt/plugin/ui/console/SltConsole.java
+++ b/src/main/java/com/en_circle/slt/plugin/ui/console/SltConsole.java
@@ -109,7 +109,7 @@ public abstract class SltConsole implements SltComponent {
     protected void eval(String data) {
         try {
             if (StringUtils.isNotBlank(data)) {
-                String setToStar = String.format("(setf * %s)", data);
+                String setToStar = String.format("(cl::setf cl::* %s)", data);
                 LispEnvironmentService.getInstance(project).sendToLisp(Eval.eval(setToStar, currentPackage,
                         result -> {
                             resultData.clear();


### PR DESCRIPTION
Previously the following would cause a bug:

```
> (make-package :horse)
> (in-package :horse)
> (cl::use-package "CL")
```

This was because `setf` and `*` were not in the `:horse` package.

Is there a plan to use swank-repl in future?